### PR TITLE
Add a colon to the paymentPointer option in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ document.onreadystatechange = function () {
       // The scale of the amount (default: 9)
       assetScale: 5,
       // Pointer to the test wallet (default: web monetization meta tag on the page)
-      paymentPointer "$coil.xrptipbot.com/LKAS89_AFOI82"
+      paymentPointer: "$coil.xrptipbot.com/LKAS89_AFOI82"
   }
   ```
 


### PR DESCRIPTION
There was a colon missing from the read me in the options section, so I added it.